### PR TITLE
Migrate from PCRE to PCRE2

### DIFF
--- a/HISTORY
+++ b/HISTORY
@@ -16,6 +16,7 @@ VDR Plugin 'epgfixer' Revision History
 - Support for new Makefile of VDR >= 1.7.34.
 - Report an error if PCRE library is not available.
 - Fix replacing at the end of string when using s///. Fix variable name clash.
+- Migrate to PCRE2
 
 2012-11-28: Version 0.3.1
 

--- a/Makefile
+++ b/Makefile
@@ -32,10 +32,10 @@ export CFLAGS   = $(call PKGCFG,cflags)
 export CXXFLAGS = $(call PKGCFG,cxxflags)
 
 ### Regexp
-ifeq (exists, $(shell pkg-config libpcre && echo exists))
-	REGEXLIB = pcre
+ifeq (exists, $(shell pkg-config libpcre2-posix && echo exists))
+	REGEXLIB = pcre2
 else
-$(error PCRE library required)
+$(error PCRE2 library required)
 endif
 
 ### The version number of VDR's plugin API:
@@ -69,10 +69,10 @@ endif
 
 OBJS = $(PLUGIN).o blacklist.o charset.o config.o epgclone.o epghandler.o regexp.o setup_menu.o tools.o
 
-ifeq ($(REGEXLIB), pcre)
-LIBS += $(shell pcre-config --libs-posix)
-INCLUDES += $(shell pcre-config --cflags)
-DEFINES += -DHAVE_PCREPOSIX
+ifeq ($(REGEXLIB), pcre2)
+LIBS += $(shell pcre2-config --libs-posix)
+INCLUDES += $(shell pcre2-config --cflags)
+DEFINES += -DHAVE_PCRE2POSIX
 endif
 
 ### The main target:

--- a/README
+++ b/README
@@ -12,7 +12,7 @@ See the file COPYING for more information.
 
 Requirements:
  - VDR 1.7.26 or later
- - PCRE library
+ - PCRE2 library
 
 Description:
 

--- a/regexp.h
+++ b/regexp.h
@@ -8,8 +8,9 @@
 #ifndef __EPGFIXER_REGEXP_H_
 #define __EPGFIXER_REGEXP_H_
 
-#ifdef HAVE_PCREPOSIX
-#include <pcre.h>
+#ifdef HAVE_PCRE2POSIX
+#define PCRE2_CODE_UNIT_WIDTH 8
+#include <pcre2.h>
 #endif
 
 #include <vdr/epg.h>
@@ -29,10 +30,8 @@ private:
   int modifiers;
   int csource;
   int source;
-  pcre *cre;
-  pcre *re;
-  pcre_extra *csd;
-  pcre_extra *sd;
+  pcre2_code *cre;
+  pcre2_code *re;
   void Compile();
   void FreeCompiled();
   int ParseModifiers(char *modstring, int substitution = 0);


### PR DESCRIPTION
Update to using PCRE2 as PCRE is obsolete and being removed from distributions. 
Needs to be run tested by a vdr-plugin-fixer regex user.

- ref: https://github.com/PCRE2Project/pcre2/issues/51